### PR TITLE
Use agent instead of agentId

### DIFF
--- a/ai/rag/main-route.camel.yaml
+++ b/ai/rag/main-route.camel.yaml
@@ -15,9 +15,9 @@
             json: {}
         - to:
             id: to-3384
-            uri: langchain4j-agent
+            uri: langchain4j-agent:agent
             parameters:
-              agentId: "#ollama"
+              agent: '#ollama'
         - log:
             id: log-4263
             message: ${body}


### PR DESCRIPTION
it is better to use agent with the bean reference, as per documentation https://camel.apache.org/components/4.18.x/langchain4j-agent-component.html#_query_parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI agent endpoint configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->