### PR TITLE
Use the the latest 1.2-SNAPSHOT version and 4.18.2 Camel

### DIFF
--- a/ai/rag/README.md
+++ b/ai/rag/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to use Camel Forage to automatically configure an 
 
 1. **Forage plugin** installed:
    ```bash
-   camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.1-SNAPSHOT
+   camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.2-SNAPSHOT
    ```
 
 2. **Ollama** running on `http://localhost:11434` with `granite4:3b` and `nomic-embed-text` models.
@@ -26,8 +26,8 @@ The `forage-agent-factory.properties` file configures the AI agent:
 
 ```bash
 camel run main-route.camel.yaml forage-agent-factory.properties company-knowledge-base.txt  \
-      --dep=mvn:io.kaoto.forage:forage-in-memory-store:1.1-SNAPSHOT \
-      --dep=mvn:io.kaoto.forage:forage-default-retrieval-augmentor:1.1-SNAPSHOT
+      --dep=mvn:io.kaoto.forage:forage-in-memory-store:1.2-SNAPSHOT \
+      --dep=mvn:io.kaoto.forage:forage-default-retrieval-augmentor:1.2-SNAPSHOT
 ```
 
 The forage plugin auto-discovers most dependencies from the properties files. The RAG-specific dependencies (`forage-in-memory-store` and `forage-default-retrieval-augmentor`) still need to be specified explicitly (see [KaotoIO/forage#229](https://github.com/KaotoIO/forage/issues/229)).

--- a/ai/rag/run-rag-agent.sh
+++ b/ai/rag/run-rag-agent.sh
@@ -1,3 +1,3 @@
 camel run main-route.camel.yaml forage-agent-factory.properties company-knowledge-base.txt  \
-      --dep=mvn:io.kaoto.forage:forage-in-memory-store:1.1-SNAPSHOT \
-      --dep=mvn:io.kaoto.forage:forage-default-retrieval-augmentor:1.1-SNAPSHOT
+      --dep=mvn:io.kaoto.forage:forage-in-memory-store:1.2-SNAPSHOT \
+      --dep=mvn:io.kaoto.forage:forage-default-retrieval-augmentor:1.2-SNAPSHOT

--- a/datasource/aggregation/README.md
+++ b/datasource/aggregation/README.md
@@ -35,7 +35,7 @@ The aggregation completes when either condition is met:
 
 1. **Install the Forage plugin**:
    ```bash
-   camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.1-SNAPSHOT
+   camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.2-SNAPSHOT
    ```
 
 2. **Start PostgreSQL**

--- a/datasource/event-booking/README.md
+++ b/datasource/event-booking/README.md
@@ -25,7 +25,7 @@ The application handles event seat reservations through a file-based workflow:
 - Apache Camel JBang
 - **Forage plugin** installed:
   ```bash
-  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.1-SNAPSHOT
+  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.2-SNAPSHOT
   ```
 
 ### 1. Create Database Schema

--- a/datasource/idempotent/README.md
+++ b/datasource/idempotent/README.md
@@ -19,7 +19,7 @@ The integration monitors the `data/inbox` directory for files and uses a Postgre
 - PostgreSQL accessible (default: localhost:5432)
 - **Forage plugin** installed:
   ```bash
-  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.1-SNAPSHOT
+  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.2-SNAPSHOT
   ```
 
 ## Configuration

--- a/datasource/multi/README.md
+++ b/datasource/multi/README.md
@@ -9,7 +9,7 @@ This project demonstrates how to use Camel Forage to run Apache Camel routes tha
 - Maven (for Spring Boot export)
 - **Forage plugin** installed:
   ```bash
-  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.1-SNAPSHOT
+  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.2-SNAPSHOT
   ```
 
 ## Database Setup
@@ -73,7 +73,7 @@ Export the project to a Spring Boot or Quarkus application:
 ```bash
 camel export route.camel.yaml application.properties \
   --runtime=spring-boot \
-  --gav=com.foo:acme:1.1-SNAPSHOT
+  --gav=com.foo:acme:1.2-SNAPSHOT
 ```
 
 ```bash

--- a/datasource/single/README.md
+++ b/datasource/single/README.md
@@ -9,7 +9,7 @@ This guide demonstrates how to use Camel Forage to run Camel Routes that interac
 - Maven (for Spring Boot export)
 - **Forage plugin** installed:
   ```bash
-  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.1-SNAPSHOT
+  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.2-SNAPSHOT
   ```
 
 ## Quick Start
@@ -58,7 +58,7 @@ The integration automatically creates a single datasource named `dataSource` fol
 ```bash
 camel export route.camel.yaml application.properties \
   --runtime=spring-boot \
-  --gav=com.foo:acme:1.1-SNAPSHOT
+  --gav=com.foo:acme:1.2-SNAPSHOT
 ```
 
 ```bash

--- a/jms/single/README.md
+++ b/jms/single/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to use Camel Forage to automatically configure a J
 
 1. **Forage plugin** installed:
    ```bash
-   camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.1-SNAPSHOT
+   camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.2-SNAPSHOT
    ```
 
 2. **ActiveMQ Artemis** running on `localhost:61616`

--- a/jms/transactional/README.md
+++ b/jms/transactional/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to use Camel Forage with XA transactions for relia
 **Forage plugin** installed:
 
 ```bash
-camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.1-SNAPSHOT
+camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.2-SNAPSHOT
 ```
 
 ActiveMQ Artemis running on `localhost:61616`:

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -31,7 +31,7 @@ This is a transaction demonstration scenario where:
 Install the forage plugin:
 
 ```bash
-camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.1-SNAPSHOT
+camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.2-SNAPSHOT
 ```
 
 ### PostgreSQL


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin and Maven dependency versions from 1.1-SNAPSHOT to 1.2-SNAPSHOT across all documentation guides and configuration files
  * Updated runtime library versions in scripts and configuration examples to align with the latest snapshot release
  * Synchronized plugin installation and export commands to use the 1.2-SNAPSHOT dependency versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->