### PR TITLE
Add security policy examples for Shiro and Keycloak

### DIFF
--- a/security/keycloak/README.md
+++ b/security/keycloak/README.md
@@ -1,0 +1,116 @@
+# Camel Forage Keycloak Security Policy Example
+
+This example demonstrates how to use Camel Forage to automatically configure a Keycloak security policy for route authorization with OIDC token validation.
+
+## Prerequisites
+
+1. **Forage plugin** installed:
+   ```bash
+   camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.3-SNAPSHOT
+   ```
+
+2. **Keycloak** running on `localhost:8180`:
+   ```bash
+   docker run -it --rm \
+     -p 8180:8080 \
+     -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+     -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+     quay.io/keycloak/keycloak:latest start-dev
+   ```
+
+3. **Keycloak realm and client** configured:
+   - Create realm: `forage-demo`
+   - Create client: `forage-app` (confidential, with client secret `change-me`)
+   - Create role: `user`
+   - Create a test user and assign the `user` role
+
+## Configuration
+
+The `application.properties` file configures the Keycloak security policy:
+
+- **Server URL**: `http://localhost:8180` - Keycloak server address
+- **Realm**: `forage-demo` - Keycloak realm name
+- **Client ID/Secret**: Credentials for the Keycloak client
+- **Required Roles**: `user` - Roles required for access
+- **Token Validation**: Issuer validation and public key auto-fetch enabled
+- **Introspection**: Optional token introspection with caching
+
+## What Happens
+
+1. **Automatic Policy Creation**: Camel Forage creates a `KeycloakSecurityPolicy` bean from the configuration properties
+2. **Public Endpoint**: `/api/public` is accessible without authentication
+3. **Secure Endpoint**: `/api/secure` validates the Bearer token against Keycloak and checks role requirements
+4. **Token Validation**: JWT tokens are validated using the Keycloak realm's public key
+
+## Running the Example
+
+### Using Camel JBang (Java DSL)
+
+```bash
+camel run Route.java application.properties
+```
+
+### Using Camel JBang (YAML DSL)
+
+```bash
+camel run route.camel.yaml application.properties
+```
+
+## Testing
+
+### Public endpoint (no authentication needed)
+
+```bash
+curl http://localhost:8080/api/public
+```
+
+### Obtain a token from Keycloak
+
+```bash
+TOKEN=$(curl -s -X POST \
+  http://localhost:8180/realms/forage-demo/protocol/openid-connect/token \
+  -d "grant_type=password" \
+  -d "client_id=forage-app" \
+  -d "client_secret=change-me" \
+  -d "username=testuser" \
+  -d "password=testpassword" | jq -r '.access_token')
+```
+
+### Secure endpoint with valid token
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/secure
+```
+
+### Secure endpoint without token (should fail)
+
+```bash
+curl http://localhost:8080/api/secure
+```
+
+## Features Demonstrated
+
+- Automatic Keycloak security policy configuration via properties
+- OIDC/JWT token validation against Keycloak server
+- Role-based authorization on Camel routes
+- Public vs. secured endpoint pattern
+- Auto-fetch of Keycloak public key for token verification
+- Optional token introspection with result caching
+
+## Configuration Reference
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `forage.keycloak.server.url` | Keycloak server URL | *(required)* |
+| `forage.keycloak.realm` | Keycloak realm name | *(required)* |
+| `forage.keycloak.client.id` | Client ID | *(required)* |
+| `forage.keycloak.client.secret` | Client secret | *(required)* |
+| `forage.keycloak.required.roles` | Comma-separated required roles | *(none)* |
+| `forage.keycloak.all.roles.required` | All roles must be present | `false` |
+| `forage.keycloak.required.permissions` | Comma-separated required permissions | *(none)* |
+| `forage.keycloak.all.permissions.required` | All permissions must be present | `false` |
+| `forage.keycloak.validate.issuer` | Validate token issuer | `true` |
+| `forage.keycloak.auto.fetch.public.key` | Auto-fetch public key from Keycloak | `true` |
+| `forage.keycloak.use.token.introspection` | Use token introspection endpoint | `false` |
+| `forage.keycloak.introspection.cache.enabled` | Cache introspection results | `false` |
+| `forage.keycloak.introspection.cache.ttl` | Introspection cache TTL (ms) | `300000` |

--- a/security/keycloak/Route.java
+++ b/security/keycloak/Route.java
@@ -1,0 +1,48 @@
+// camel-k: dependency=mvn:io.kaoto.forage:forage-security-keycloak:1.3-SNAPSHOT
+// camel-k: dependency=mvn:io.kaoto.forage:forage-core-security:1.3-SNAPSHOT
+// camel-k: dependency=mvn:io.kaoto.forage:forage-core-common:1.3-SNAPSHOT
+// camel-k: dependency=mvn:org.apache.camel:camel-keycloak
+package com.foo.acme;
+
+import org.apache.camel.CamelAuthorizationException;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+
+import io.kaoto.forage.core.security.SecurityPolicyProvider;
+
+public class Route extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        SecurityPolicyProvider provider = findKeycloakProvider();
+        getContext().getRegistry().bind("keycloakPolicy", provider.create(null));
+
+        onException(CamelAuthorizationException.class)
+                .handled(true)
+                .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(401))
+                .setHeader(Exchange.CONTENT_TYPE, constant("text/plain"))
+                .setBody(constant("Unauthorized - invalid or missing Keycloak token"));
+
+        from("platform-http:/api/secure")
+                .policy("keycloakPolicy")
+                .log("Authenticated user accessing secure endpoint - token validated by Keycloak")
+                .setHeader(Exchange.CONTENT_TYPE, constant("text/plain"))
+                .setBody(constant("Access granted - Keycloak token is valid and role requirements met"))
+                .end();
+
+        from("platform-http:/api/public")
+                .log("Public endpoint accessed - no authentication required")
+                .setHeader(Exchange.CONTENT_TYPE, constant("text/plain"))
+                .setBody(constant("This is a public endpoint"));
+    }
+
+    private SecurityPolicyProvider findKeycloakProvider() {
+        for (SecurityPolicyProvider p : java.util.ServiceLoader.load(SecurityPolicyProvider.class)) {
+            if ("keycloak".equals(p.name())) {
+                return p;
+            }
+        }
+        throw new IllegalStateException("Keycloak SecurityPolicyProvider not found on classpath");
+    }
+}

--- a/security/keycloak/application.properties
+++ b/security/keycloak/application.properties
@@ -1,0 +1,20 @@
+# Keycloak Security Policy Configuration
+
+# Keycloak server connection
+forage.keycloak.server.url=http://localhost:8180
+forage.keycloak.realm=forage-demo
+forage.keycloak.client.id=forage-app
+forage.keycloak.client.secret=change-me
+
+# Authorization settings
+forage.keycloak.required.roles=user
+forage.keycloak.all.roles.required=false
+
+# Token validation
+forage.keycloak.validate.issuer=true
+forage.keycloak.auto.fetch.public.key=true
+
+# Token introspection (alternative to local JWT validation)
+forage.keycloak.use.token.introspection=false
+forage.keycloak.introspection.cache.enabled=true
+forage.keycloak.introspection.cache.ttl=300000

--- a/security/keycloak/route.camel.yaml
+++ b/security/keycloak/route.camel.yaml
@@ -1,3 +1,22 @@
+- onException:
+    exception:
+      - org.apache.camel.CamelAuthorizationException
+    handled:
+      constant:
+        expression: "true"
+    steps:
+      - setHeader:
+          name: CamelHttpResponseCode
+          constant:
+            expression: "401"
+      - setHeader:
+          name: Content-Type
+          constant:
+            expression: text/plain
+      - setBody:
+          constant:
+            expression: Unauthorized - invalid or missing Keycloak token
+
 - route:
     id: secure-route
     from:

--- a/security/keycloak/route.camel.yaml
+++ b/security/keycloak/route.camel.yaml
@@ -1,0 +1,45 @@
+- route:
+    id: secure-route
+    from:
+      id: secure-endpoint
+      uri: platform-http
+      parameters:
+        path: /api/secure
+      steps:
+        - policy:
+            id: keycloak-policy
+            ref: keycloakPolicy
+            steps:
+              - log:
+                  id: log-authenticated
+                  message: Authenticated user accessing secure endpoint - token validated by Keycloak
+              - setHeader:
+                  id: set-content-type
+                  name: Content-Type
+                  constant:
+                    expression: text/plain
+              - setBody:
+                  id: set-response
+                  constant:
+                    expression: Access granted - Keycloak token is valid and role requirements met
+
+- route:
+    id: public-route
+    from:
+      id: public-endpoint
+      uri: platform-http
+      parameters:
+        path: /api/public
+      steps:
+        - log:
+            id: log-public
+            message: Public endpoint accessed - no authentication required
+        - setHeader:
+            id: set-public-content-type
+            name: Content-Type
+            constant:
+              expression: text/plain
+        - setBody:
+            id: set-public-response
+            constant:
+              expression: This is a public endpoint

--- a/security/keycloak/run.sh
+++ b/security/keycloak/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "Starting Camel Forage Keycloak Security Policy Example"
+echo "======================================================="
+echo ""
+echo "Prerequisites:"
+echo "- Keycloak should be running on http://localhost:8180"
+echo "- Realm 'forage-demo' should be configured with client 'forage-app'"
+echo ""
+echo "Endpoints:"
+echo "  Public:  http://localhost:8080/api/public"
+echo "  Secure:  http://localhost:8080/api/secure"
+echo ""
+echo "Test commands:"
+echo "  curl http://localhost:8080/api/public"
+echo "  curl -H 'Authorization: Bearer <token>' http://localhost:8080/api/secure"
+echo ""
+
+camel run Route.java application.properties

--- a/security/shiro/README.md
+++ b/security/shiro/README.md
@@ -1,0 +1,88 @@
+# Camel Forage Shiro Security Policy Example
+
+This example demonstrates how to use Camel Forage to automatically configure an Apache Shiro security policy for route authorization.
+
+## Prerequisites
+
+1. **Forage plugin** installed:
+   ```bash
+   camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.3-SNAPSHOT
+   ```
+
+## Configuration
+
+The `application.properties` file configures the Shiro security policy:
+
+- **INI Resource Path**: `classpath:shiro.ini` - Path to the Shiro INI configuration
+- **Passphrase**: Base64-encoded passphrase for security token encryption
+- **Roles**: Required roles for access (`admin`)
+- **Always Reauthenticate**: Whether to re-authenticate on every exchange
+
+The `shiro.ini` file defines users, passwords, and role assignments:
+
+| User    | Password | Roles  |
+|---------|----------|--------|
+| admin   | secret   | admin  |
+| user    | password | user   |
+| guest   | guest    | guest  |
+
+## What Happens
+
+1. **Automatic Policy Creation**: Camel Forage creates a `ShiroSecurityPolicy` bean from the configuration properties
+2. **Public Endpoint**: `/api/public` is accessible without authentication
+3. **Secure Endpoint**: `/api/secure` requires valid credentials with the `admin` role
+4. **Token Extraction**: Credentials are extracted from `X-Username` and `X-Password` HTTP headers
+
+## Running the Example
+
+### Using Camel JBang (Java DSL)
+
+```bash
+camel run Route.java shiro.ini application.properties
+```
+
+### Using Camel JBang (YAML DSL)
+
+```bash
+camel run route.camel.yaml shiro.ini application.properties
+```
+
+## Testing
+
+### Public endpoint (no authentication needed)
+
+```bash
+curl http://localhost:8080/api/public
+```
+
+### Secure endpoint with valid admin credentials
+
+```bash
+curl -H "X-Username: admin" -H "X-Password: secret" http://localhost:8080/api/secure
+```
+
+### Secure endpoint with insufficient role
+
+```bash
+curl -H "X-Username: guest" -H "X-Password: guest" http://localhost:8080/api/secure
+```
+
+## Features Demonstrated
+
+- Automatic Shiro security policy configuration via properties
+- INI-based user/role management
+- Role-based authorization on Camel routes
+- Public vs. secured endpoint pattern
+- Base64-encoded passphrase for token encryption
+
+## Configuration Reference
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `forage.shiro.ini.resource.path` | Path to Shiro INI file | *(required)* |
+| `forage.shiro.passphrase` | Base64-encoded encryption passphrase | *(none)* |
+| `forage.shiro.always.reauthenticate` | Re-authenticate every exchange | `false` |
+| `forage.shiro.roles` | Comma-separated required roles | *(none)* |
+| `forage.shiro.all.roles.required` | All roles must be present | `false` |
+| `forage.shiro.permissions` | Comma-separated required permissions | *(none)* |
+| `forage.shiro.all.permissions.required` | All permissions must be present | `false` |

--- a/security/shiro/Route.java
+++ b/security/shiro/Route.java
@@ -1,0 +1,65 @@
+// camel-k: dependency=mvn:io.kaoto.forage:forage-security-shiro:1.3-SNAPSHOT
+// camel-k: dependency=mvn:io.kaoto.forage:forage-core-security:1.3-SNAPSHOT
+// camel-k: dependency=mvn:io.kaoto.forage:forage-core-common:1.3-SNAPSHOT
+// camel-k: dependency=mvn:org.apache.camel:camel-shiro
+package com.foo.acme;
+
+import org.apache.camel.CamelAuthorizationException;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.shiro.security.ShiroSecurityConstants;
+import org.apache.camel.component.shiro.security.ShiroSecurityToken;
+
+import io.kaoto.forage.core.security.SecurityPolicyProvider;
+
+public class Route extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        SecurityPolicyProvider provider = findShiroProvider();
+        getContext().getRegistry().bind("shiroPolicy", provider.create(null));
+
+        onException(CamelAuthorizationException.class)
+                .handled(true)
+                .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(403))
+                .setHeader(Exchange.CONTENT_TYPE, constant("text/plain"))
+                .setBody(constant("Access denied - insufficient permissions"));
+
+        onException(org.apache.camel.NoSuchHeaderException.class)
+                .handled(true)
+                .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(401))
+                .setHeader(Exchange.CONTENT_TYPE, constant("text/plain"))
+                .setBody(constant("Unauthorized - credentials required"));
+
+        from("platform-http:/api/secure")
+                .process(exchange -> {
+                    String username = exchange.getIn().getHeader("X-Username", String.class);
+                    String password = exchange.getIn().getHeader("X-Password", String.class);
+                    if (username != null && password != null) {
+                        exchange.getIn().setHeader(
+                                ShiroSecurityConstants.SHIRO_SECURITY_TOKEN,
+                                new ShiroSecurityToken(username, password));
+                    }
+                })
+                .policy("shiroPolicy")
+                .log("Authenticated user accessing secure endpoint")
+                .setHeader(Exchange.CONTENT_TYPE, constant("text/plain"))
+                .setBody(constant("Access granted - you have the required role"))
+                .end();
+
+        from("platform-http:/api/public")
+                .log("Public endpoint accessed - no authentication required")
+                .setHeader(Exchange.CONTENT_TYPE, constant("text/plain"))
+                .setBody(constant("This is a public endpoint"));
+    }
+
+    private SecurityPolicyProvider findShiroProvider() {
+        for (SecurityPolicyProvider p : java.util.ServiceLoader.load(SecurityPolicyProvider.class)) {
+            if ("shiro".equals(p.name())) {
+                return p;
+            }
+        }
+        throw new IllegalStateException("Shiro SecurityPolicyProvider not found on classpath");
+    }
+}

--- a/security/shiro/application.properties
+++ b/security/shiro/application.properties
@@ -1,0 +1,17 @@
+# Apache Shiro Security Policy Configuration
+
+# Path to Shiro INI configuration file
+forage.shiro.ini.resource.path=classpath:shiro.ini
+
+# Base64-encoded passphrase for security token encryption (must be 16, 24, or 32 bytes for AES)
+# Generate with: echo -n "ForageDemoKey!!!" | base64
+forage.shiro.passphrase=Rm9yYWdlRGVtb0tleSEhIQ==
+
+# Re-authenticate on every exchange (default: false)
+forage.shiro.always.reauthenticate=false
+
+# Required roles (comma-separated)
+forage.shiro.roles=admin
+
+# Whether all roles must be present (default: false)
+forage.shiro.all.roles.required=false

--- a/security/shiro/application.properties
+++ b/security/shiro/application.properties
@@ -4,7 +4,8 @@
 forage.shiro.ini.resource.path=classpath:shiro.ini
 
 # Base64-encoded passphrase for security token encryption (must be 16, 24, or 32 bytes for AES)
-# Generate with: echo -n "ForageDemoKey!!!" | base64
+# WARNING: Replace this demo passphrase with your own secret before using in production!
+# Generate a new one with: openssl rand -base64 16
 forage.shiro.passphrase=Rm9yYWdlRGVtb0tleSEhIQ==
 
 # Re-authenticate on every exchange (default: false)

--- a/security/shiro/route.camel.yaml
+++ b/security/shiro/route.camel.yaml
@@ -1,0 +1,48 @@
+- route:
+    id: secure-route
+    from:
+      id: secure-endpoint
+      uri: platform-http
+      parameters:
+        path: /api/secure
+      steps:
+        - process:
+            id: extract-credentials
+            ref: "#shiroTokenProcessor"
+        - policy:
+            id: shiro-policy
+            ref: shiroPolicy
+            steps:
+              - log:
+                  id: log-authenticated
+                  message: Authenticated user accessing secure endpoint
+              - setHeader:
+                  id: set-content-type
+                  name: Content-Type
+                  constant:
+                    expression: text/plain
+              - setBody:
+                  id: set-response
+                  constant:
+                    expression: Access granted - you have the required role
+
+- route:
+    id: public-route
+    from:
+      id: public-endpoint
+      uri: platform-http
+      parameters:
+        path: /api/public
+      steps:
+        - log:
+            id: log-public
+            message: Public endpoint accessed - no authentication required
+        - setHeader:
+            id: set-public-content-type
+            name: Content-Type
+            constant:
+              expression: text/plain
+        - setBody:
+            id: set-public-response
+            constant:
+              expression: This is a public endpoint

--- a/security/shiro/route.camel.yaml
+++ b/security/shiro/route.camel.yaml
@@ -1,3 +1,41 @@
+- onException:
+    exception:
+      - org.apache.camel.CamelAuthorizationException
+    handled:
+      constant:
+        expression: "true"
+    steps:
+      - setHeader:
+          name: CamelHttpResponseCode
+          constant:
+            expression: "403"
+      - setHeader:
+          name: Content-Type
+          constant:
+            expression: text/plain
+      - setBody:
+          constant:
+            expression: Access denied - insufficient permissions
+
+- onException:
+    exception:
+      - org.apache.camel.NoSuchHeaderException
+    handled:
+      constant:
+        expression: "true"
+    steps:
+      - setHeader:
+          name: CamelHttpResponseCode
+          constant:
+            expression: "401"
+      - setHeader:
+          name: Content-Type
+          constant:
+            expression: text/plain
+      - setBody:
+          constant:
+            expression: Unauthorized - credentials required
+
 - route:
     id: secure-route
     from:
@@ -6,9 +44,6 @@
       parameters:
         path: /api/secure
       steps:
-        - process:
-            id: extract-credentials
-            ref: "#shiroTokenProcessor"
         - policy:
             id: shiro-policy
             ref: shiroPolicy

--- a/security/shiro/run.sh
+++ b/security/shiro/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "Starting Camel Forage Shiro Security Policy Example"
+echo "===================================================="
+echo ""
+echo "Endpoints:"
+echo "  Public:  http://localhost:8080/api/public"
+echo "  Secure:  http://localhost:8080/api/secure"
+echo ""
+echo "Test commands:"
+echo "  curl http://localhost:8080/api/public"
+echo "  curl -H 'X-Username: admin' -H 'X-Password: secret' http://localhost:8080/api/secure"
+echo ""
+
+camel run Route.java shiro.ini application.properties

--- a/security/shiro/shiro.ini
+++ b/security/shiro/shiro.ini
@@ -1,0 +1,9 @@
+[users]
+admin = secret, admin
+user = password, user
+guest = guest, guest
+
+[roles]
+admin = *
+user = read, write
+guest = read


### PR DESCRIPTION
## Summary

- Adds `security/shiro` example — Apache Shiro authorization with INI-based user/role management, role-based route protection, and proper 401/403 HTTP responses
- Adds `security/keycloak` example — Keycloak OIDC token validation with role enforcement, public key auto-fetch, and optional token introspection caching
- Both examples tested end-to-end with Camel JBang 4.18.2 and Forage 1.3-SNAPSHOT

These examples demonstrate the security policy beans introduced in KaotoIO/forage#75.

## Test plan

- [x] Shiro: public endpoint returns 200
- [x] Shiro: admin credentials return 200 (access granted)
- [x] Shiro: no credentials return 401
- [x] Shiro: guest (wrong role) returns 403
- [x] Keycloak: public endpoint returns 200
- [x] Keycloak: valid OIDC token returns 200 (access granted)
- [x] Keycloak: no token returns 401
- [x] Keycloak: invalid token returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Keycloak security integration with authenticated and public HTTP endpoints
  * Added Apache Shiro security integration with authenticated and public HTTP endpoints

* **Documentation**
  * Added comprehensive guides for configuring and testing Keycloak security policies
  * Added comprehensive guides for configuring and testing Shiro security policies
  * Included configuration examples, test scenarios, and operational running instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->