### PR TITLE
Use {{env:}} and {{sys:}} placeholders in datasource example

### DIFF
--- a/datasource/single/README.md
+++ b/datasource/single/README.md
@@ -9,7 +9,7 @@ This guide demonstrates how to use Camel Forage to run Camel Routes that interac
 - Maven (for Spring Boot export)
 - **Forage plugin** installed:
   ```bash
-  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.3-SNAPSHOT
+  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.4-SNAPSHOT
   ```
 
 ## Quick Start
@@ -58,7 +58,7 @@ The integration automatically creates a single datasource named `dataSource` fol
 ```bash
 camel export route.camel.yaml application.properties \
   --runtime=spring-boot \
-  --gav=com.foo:acme:1.3-SNAPSHOT
+  --gav=com.foo:acme:1.4-SNAPSHOT
 ```
 
 ```bash

--- a/datasource/single/README.md
+++ b/datasource/single/README.md
@@ -22,11 +22,11 @@ Launch PostgreSQL using Camel infrastructure:
 camel infra run postgres
 ```
 
-**Connection Details:**
-- Host: `localhost`
-- Port: `5432`
-- Username: `test`
-- Password: `test`
+**Connection Details (defaults):**
+- Host: `localhost` (override with `DB_HOST`)
+- Port: `5432` (override with `DB_PORT`)
+- Username: `test` (override with `DB_USER`)
+- Password: `test` (override with `DB_PASSWORD`)
 - JDBC URL: `jdbc:postgresql://localhost:5432/postgres`
 
 ### 2. Set Up Test Data

--- a/datasource/single/application.properties
+++ b/datasource/single/application.properties
@@ -1,9 +1,9 @@
 # PostgreSQL JDBC Configuration
 # Database connection settings
 forage.jdbc.db.kind=postgresql
-forage.jdbc.url=jdbc:postgresql://localhost:5432/postgres
-forage.jdbc.username=test
-forage.jdbc.password=test
+forage.jdbc.url=jdbc:postgresql://{{env:DB_HOST:localhost}}:{{env:DB_PORT:5432}}/{{sys:forage.db.name:postgres}}
+forage.jdbc.username={{env:DB_USER:test}}
+forage.jdbc.password={{env:DB_PASSWORD:test}}
 
 # Connection pool settings
 forage.jdbc.pool.initial.size=5


### PR DESCRIPTION
## Summary
- Upgrade forage plugin version to 1.4-SNAPSHOT
- Update single datasource example to demonstrate `{{env:KEY:default}}` and `{{sys:KEY:default}}` placeholder syntax

Depends on KaotoIO/forage#376