### PR TITLE
Add Spring RabbitMQ connection factory example

### DIFF
--- a/rabbitmq/README.adoc
+++ b/rabbitmq/README.adoc
@@ -1,0 +1,118 @@
+= Camel Forage Spring RabbitMQ Example
+
+This example demonstrates how to use Camel Forage to automatically configure a Spring RabbitMQ ConnectionFactory with RabbitMQ.
+
+== Prerequisites
+
+. *Forage plugin* installed:
+ `bash
+   camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.4-SNAPSHOT
+`
+
+. *RabbitMQ* running on `localhost:5672`
+ `bash
+   camel infra run rabbitmq
+`
+
+or
+
+`bash
+   # Using Docker
+   docker run -it --rm \
+     -p 5672:5672 \
+     -p 15672:15672 \
+     -e RABBITMQ_DEFAULT_USER=guest \
+     -e RABBITMQ_DEFAULT_PASS=guest \
+     rabbitmq:3-management
+`
+
+The RabbitMQ management UI will be available at http://localhost:15672 (guest/guest)
+
+== Configuration
+
+The `application.properties` file configures the RabbitMQ connection:
+
+* *Host*: `localhost` - RabbitMQ broker hostname
+* *Port*: `5672` - AMQP port
+* *Virtual Host*: `/` - Default virtual host
+* *Credentials*: Username/password for authentication (guest/guest)
+* *Auto-declare*: Automatically creates exchanges and queues
+
+== What Happens
+
+. *Automatic ConnectionFactory Creation*: Camel Forage automatically creates and configures a `CachingConnectionFactory` named `rabbitConnectionFactory` in the Camel registry
+. *Timer Producer*: Sends a message every 5 seconds to the `test.exchange` with routing key `test`
+. *RabbitMQ Consumer*: Receives and logs messages from `test.queue` bound to `test.exchange`
+
+== Running the Example
+
+=== Using Camel JBang (Java DSL)
+
+[source,bash]
+----
+camel run Route.java application.properties
+----
+
+=== Using Camel JBang (YAML DSL)
+
+[source,bash]
+----
+camel run route.camel.yaml application.properties
+----
+
+=== Using the helper script
+
+[source,bash]
+----
+./run.sh
+----
+
+The forage plugin auto-discovers the required dependencies from the properties files, so no `--dep` flags are needed.
+
+== Export
+
+Export the project to a Spring Boot or Quarkus application:
+
+=== Spring Boot
+
+[source,bash]
+----
+camel export route.camel.yaml application.properties \
+  --runtime=spring-boot \
+  --gav=com.foo:acme:1.4-SNAPSHOT \
+  --dir=spring-boot-rabbitmq
+----
+
+[source,bash]
+----
+cd spring-boot-rabbitmq
+mvn spring-boot:run
+----
+
+=== Quarkus
+
+[source,bash]
+----
+camel export route.camel.yaml application.properties \
+  --runtime=quarkus \
+  --dir=quarkus-rabbitmq
+----
+
+[source,bash]
+----
+cd quarkus-rabbitmq
+mvn clean compile quarkus:dev
+----
+
+== Features Demonstrated
+
+* ✅ Automatic Spring RabbitMQ ConnectionFactory configuration via properties
+* ✅ Connection caching with Spring's CachingConnectionFactory
+* ✅ Producer/Consumer pattern
+* ✅ Exchange and queue auto-declaration
+* ✅ Zero boilerplate - no manual ConnectionFactory setup needed
+
+== Additional Features
+
+Forage supports multiple connection factories using prefixed configuration (e.g., `forage.primary.spring.rabbitmq.host`), cluster failover with the `addresses` property, and different cache modes.
+See the https://kaotoio.github.io/forage/modules/spring-rabbitmq/[Forage Spring RabbitMQ documentation] for more details.

--- a/rabbitmq/Route.java
+++ b/rabbitmq/Route.java
@@ -1,0 +1,17 @@
+package com.foo.acme;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class Route extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("timer:producer?period=5000")
+                .setBody(constant("Hello from Camel Forage Spring RabbitMQ!"))
+                .to("spring-rabbitmq:test.exchange?routingKey=test")
+                .log("Message sent to RabbitMQ exchange");
+
+        from("spring-rabbitmq:test.exchange?queues=test.queue&routingKey=test")
+                .log("Message received from RabbitMQ: ${body}");
+    }
+}

--- a/rabbitmq/application.properties
+++ b/rabbitmq/application.properties
@@ -1,0 +1,10 @@
+# Spring RabbitMQ Configuration
+# Connection settings for RabbitMQ broker
+forage.spring.rabbitmq.host=localhost
+forage.spring.rabbitmq.port=5672
+forage.spring.rabbitmq.username=guest
+forage.spring.rabbitmq.password=guest
+forage.spring.rabbitmq.virtual.host=/
+
+# Auto-declare exchanges and queues
+camel.component.spring-rabbitmq.auto-declare=true

--- a/rabbitmq/route.camel.yaml
+++ b/rabbitmq/route.camel.yaml
@@ -1,0 +1,37 @@
+- route:
+    id: rabbitmq-producer-route
+    from:
+      id: timer-producer
+      uri: timer
+      parameters:
+        period: "5000"
+        timerName: producer
+      steps:
+        - setBody:
+            id: set-message-body
+            simple:
+              expression: Hello from Camel Forage Spring RabbitMQ!
+        - to:
+            id: send-to-rabbitmq
+            uri: spring-rabbitmq
+            parameters:
+              exchangeName: test.exchange
+              routingKey: test
+        - log:
+            id: log-sent
+            message: Message sent to RabbitMQ exchange
+
+- route:
+    id: rabbitmq-consumer-route
+    from:
+      id: rabbitmq-consumer
+      uri: spring-rabbitmq
+      parameters:
+        exchangeName: test.exchange
+        queues: test.queue
+        routingKey: test
+        connectionFactory: "#rabbitConnectionFactory"
+      steps:
+        - log:
+            id: log-received
+            message: "Message received from RabbitMQ: ${body}"

--- a/rabbitmq/run.sh
+++ b/rabbitmq/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Starting Camel Forage Spring RabbitMQ Example"
+echo "=============================================="
+echo ""
+echo "Prerequisites:"
+echo "- RabbitMQ should be running on localhost:5672"
+echo "- Start RabbitMQ with: camel infra run rabbitmq"
+echo ""
+
+camel run route.camel.yaml application.properties


### PR DESCRIPTION
Add rabbitmq-example demonstrating the forage-spring-rabbitmq module with producer/consumer pattern.

## Features
- Automatic CachingConnectionFactory configuration via properties
- Both YAML and Java DSL implementations
- Export instructions for Spring Boot and Quarkus runtimes

Fixes https://github.com/KaotoIO/forage/issues/366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a RabbitMQ integration example with timer-driven producer and consumer message routes demonstrating end-to-end send/receive behavior.

* **Documentation**
  * Added a comprehensive README and run helper describing local/Docker setup, connection configuration, running options (JBang, Spring Boot, Quarkus), and advanced capabilities like multiple connection factories and cluster failover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->