### PR TITLE
chore: create camel-latest branch aligned with Camel 4.20.0

### DIFF
--- a/datasource/single/README.md
+++ b/datasource/single/README.md
@@ -9,7 +9,7 @@ This guide demonstrates how to use Camel Forage to run Camel Routes that interac
 - Maven (for Spring Boot export)
 - **Forage plugin** installed:
   ```bash
-  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.4.0-SNAPSHOT
+  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.5.0-SNAPSHOT
   ```
 
 ## Quick Start
@@ -58,7 +58,7 @@ The integration automatically creates a single datasource named `dataSource` fol
 ```bash
 camel export route.camel.yaml application.properties \
   --runtime=spring-boot \
-  --gav=com.foo:acme:1.4.0-SNAPSHOT
+  --gav=com.foo:acme:1.5.0-SNAPSHOT
 ```
 
 ```bash

--- a/datasource/single/README.md
+++ b/datasource/single/README.md
@@ -9,7 +9,7 @@ This guide demonstrates how to use Camel Forage to run Camel Routes that interac
 - Maven (for Spring Boot export)
 - **Forage plugin** installed:
   ```bash
-  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.4-SNAPSHOT
+  camel plugin add -g=io.kaoto.forage -a=camel-jbang-plugin-forage -v=1.4.0-SNAPSHOT
   ```
 
 ## Quick Start
@@ -58,7 +58,7 @@ The integration automatically creates a single datasource named `dataSource` fol
 ```bash
 camel export route.camel.yaml application.properties \
   --runtime=spring-boot \
-  --gav=com.foo:acme:1.4-SNAPSHOT
+  --gav=com.foo:acme:1.4.0-SNAPSHOT
 ```
 
 ```bash


### PR DESCRIPTION
## Summary
- Creates the `camel-latest` branch for forage-examples tracking latest Camel release (4.20.0)
- Updates forage version references to `1.5.0-SNAPSHOT`

**Note:** This PR should be merged to create the `camel-latest` branch on the repository, not merged into `main`.

## Test plan
- [ ] Verify version references are correct for Camel 4.20